### PR TITLE
fix: normalize bins

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -10,4 +10,6 @@
   <depend package="base/types" />
   <depend package="drivers/iodrivers_base" />
   <test_depend package="google-test" />
+
+  <tags>needs_opt</tags>
 </package>

--- a/src/Driver.cpp
+++ b/src/Driver.cpp
@@ -70,7 +70,7 @@ void Driver::fireSonar(M750DConfiguration const& config)
     simple_fire_message.networkSpeed = config.net_speed_limit;
     simple_fire_message.masterMode = config.mode;
     simple_fire_message.range = config.range;
-    simple_fire_message.gainPercent = config.gain;
+    simple_fire_message.gainPercent = config.gain * 100;
     simple_fire_message.speedOfSound = config.speed_of_sound;
     simple_fire_message.salinity = config.salinity;
     simple_fire_message.extFlags = 4;

--- a/src/Driver.cpp
+++ b/src/Driver.cpp
@@ -57,7 +57,7 @@ static uint8_t setFlags(bool gain_assist);
 
 void Driver::fireSonar(M750DConfiguration const& config)
 {
-    OculusSimpleFireMessage simple_fire_message;
+    OculusSimpleFireMessage2 simple_fire_message;
     memset(&simple_fire_message, 0, sizeof(OculusSimpleFireMessage));
     simple_fire_message.head.msgId = messageSimpleFire;
     simple_fire_message.head.srcDeviceId = 0;
@@ -73,6 +73,14 @@ void Driver::fireSonar(M750DConfiguration const& config)
     simple_fire_message.gainPercent = config.gain;
     simple_fire_message.speedOfSound = config.speed_of_sound;
     simple_fire_message.salinity = config.salinity;
+    simple_fire_message.extFlags = 4;
+    std::fill(std::begin(simple_fire_message.reserved0),
+        std::end(simple_fire_message.reserved0),
+        0);
+    std::fill(std::begin(simple_fire_message.reserved1),
+        std::end(simple_fire_message.reserved1),
+        0);
+    simple_fire_message.beaconLocatorFrequency = 0;
 
     writePacket(reinterpret_cast<uint8_t*>(&simple_fire_message),
         sizeof(OculusSimpleFireMessage));

--- a/src/Protocol.cpp
+++ b/src/Protocol.cpp
@@ -1,3 +1,4 @@
+#include "Protocol.hpp"
 #include "Oculus.h"
 #include <cstdlib>
 #include <sonar_oculus_m750d/Protocol.hpp>
@@ -91,7 +92,8 @@ base::samples::Sonar Protocol::parseSonar(base::Angle const& beam_width,
         m_data.beam_count,
         false);
     auto bins = toBeamMajor(m_data.image, m_data.beam_count, m_data.bin_count);
-    sonar.bins = bins;
+    auto normalized_bins = normalizeBins(bins);
+    sonar.bins = normalized_bins;
     sonar.bearings = getBearingsAngles(m_data.bearings, m_data.beam_count);
 
     return sonar;
@@ -102,18 +104,27 @@ base::Time Protocol::binDuration(double range, double speed_of_sound, int bin_co
     return base::Time::fromSeconds(range / (speed_of_sound * bin_count));
 }
 
-std::vector<float> Protocol::toBeamMajor(std::vector<uint8_t> const& bin_first,
+std::vector<uint8_t> Protocol::toBeamMajor(std::vector<uint8_t> const& bin_first,
     uint16_t beam_count,
     uint16_t bin_count)
 {
-    std::vector<float> beam_first(beam_count * bin_count);
+    std::vector<uint8_t> beam_first(beam_count * bin_count);
     for (uint16_t b = 0; b < beam_count; b++) {
         for (uint16_t r = 0; r < bin_count; r++) {
-            beam_first[b * bin_count + r] =
-                static_cast<float>(bin_first[r * beam_count + b]);
+            beam_first[b * bin_count + r] = bin_first[r * beam_count + b];
         }
     }
     return beam_first;
+}
+
+std::vector<float> Protocol::normalizeBins(std::vector<uint8_t> const& bins)
+{
+    std::vector<float> normalized_bins;
+    normalized_bins.resize(bins.size());
+    for (size_t i = 0; i < bins.size(); i++) {
+        normalized_bins[i] = bins[i] * Protocol::NORMALIZATION_FACTOR;
+    }
+    return normalized_bins;
 }
 
 std::vector<base::Angle> getBearingsAngles(std::vector<short> const& bearings,

--- a/src/Protocol.hpp
+++ b/src/Protocol.hpp
@@ -8,6 +8,7 @@
 namespace sonar_oculus_m750d {
     class Protocol {
     public:
+        static constexpr double NORMALIZATION_FACTOR = 1.0 / 255;
         bool handleBuffer(uint8_t const* buffer);
         base::samples::Sonar parseSonar(base::Angle const& beam_width,
             base::Angle const& beam_height);
@@ -19,14 +20,14 @@ namespace sonar_oculus_m750d {
          * in beam major order, this is [idx = beam * bin_count + bin]
          *
          */
-        static std::vector<float> toBeamMajor(std::vector<uint8_t> const& bin_first,
+        static std::vector<uint8_t> toBeamMajor(std::vector<uint8_t> const& bin_first,
             uint16_t beam_count,
             uint16_t bin_count);
         static base::Time binDuration(double range, double speed_of_sound, int bin_count);
 
     private:
         void handleMessageSimplePingResult(uint8_t const* buffer, uint16_t version);
-
+        static std::vector<float> normalizeBins(std::vector<uint8_t> const& bins);
         SonarData m_data;
         bool m_simple_ping_result = false;
     };

--- a/src/Protocol.hpp
+++ b/src/Protocol.hpp
@@ -20,14 +20,14 @@ namespace sonar_oculus_m750d {
          * in beam major order, this is [idx = beam * bin_count + bin]
          *
          */
-        static std::vector<uint8_t> toBeamMajor(std::vector<uint8_t> const& bin_first,
+        static std::vector<float> toBeamMajor(std::vector<uint8_t> const& bin_first,
             uint16_t beam_count,
             uint16_t bin_count);
         static base::Time binDuration(double range, double speed_of_sound, int bin_count);
 
     private:
         void handleMessageSimplePingResult(uint8_t const* buffer, uint16_t version);
-        static std::vector<float> normalizeBins(std::vector<uint8_t> const& bins);
+        void normalizeBins(std::vector<float>& bins);
         SonarData m_data;
         bool m_simple_ping_result = false;
     };

--- a/test/test_Protocol.cpp
+++ b/test/test_Protocol.cpp
@@ -16,7 +16,7 @@ TEST_F(ProtocolTest, it_changes_the_bins_to_beam_major)
     uint16_t beam_count = 3;
     uint16_t bin_count = 2;
     auto beam_first = protocol.toBeamMajor(bins, beam_count, bin_count);
-    std::vector<uint8_t> expected_beam_first = {1, 4, 2, 5, 3, 6};
+    std::vector<float> expected_beam_first = {1, 4, 2, 5, 3, 6};
     ASSERT_EQ(expected_beam_first, beam_first);
 }
 

--- a/test/test_Protocol.cpp
+++ b/test/test_Protocol.cpp
@@ -16,7 +16,7 @@ TEST_F(ProtocolTest, it_changes_the_bins_to_beam_major)
     uint16_t beam_count = 3;
     uint16_t bin_count = 2;
     auto beam_first = protocol.toBeamMajor(bins, beam_count, bin_count);
-    std::vector<float> expected_beam_first = {1, 4, 2, 5, 3, 6};
+    std::vector<uint8_t> expected_beam_first = {1, 4, 2, 5, 3, 6};
     ASSERT_EQ(expected_beam_first, beam_first);
 }
 


### PR DESCRIPTION
# What is this PR for
fix: normalize bins
fix: use OculusSimpleFireMessage2 instead OculusSimpleFireMessage
fix: normalize gain configuration

# Checklist
- [x] Assign yourself  in the PR