### PR TITLE
feat: make the network trigger flag set configurable

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,6 +6,7 @@ rock_library(sonar_oculus_m750d
             Oculus.h
             M750DConfiguration.hpp
             SonarData.hpp
+            UpdateRate.hpp
     DEPS_PKGCONFIG base-types iodrivers_base)
 
 rock_executable(sonar_oculus_m750d_ctl Main.cpp

--- a/src/Driver.cpp
+++ b/src/Driver.cpp
@@ -53,9 +53,9 @@ std::optional<base::samples::Sonar> Driver::processOne()
     return std::nullopt;
 }
 
-static uint8_t setFlags(bool gain_assist);
+static uint8_t setFlags(bool gain_assist, bool network_trigger);
 
-void Driver::fireSonar(M750DConfiguration const& config)
+void Driver::fireSonar(M750DConfiguration const& config, bool network_trigger)
 {
     OculusSimpleFireMessage2 simple_fire_message;
     memset(&simple_fire_message, 0, sizeof(OculusSimpleFireMessage));
@@ -63,7 +63,7 @@ void Driver::fireSonar(M750DConfiguration const& config)
     simple_fire_message.head.srcDeviceId = 0;
     simple_fire_message.head.dstDeviceId = 0;
     simple_fire_message.head.oculusId = 0x4f53;
-    uint8_t flags = setFlags(config.gain_assist);
+    uint8_t flags = setFlags(config.gain_assist, network_trigger);
     simple_fire_message.flags = flags;
     simple_fire_message.gammaCorrection = config.gamma;
     simple_fire_message.pingRate = pingRateHigh;
@@ -86,7 +86,7 @@ void Driver::fireSonar(M750DConfiguration const& config)
         sizeof(OculusSimpleFireMessage));
 }
 
-uint8_t setFlags(bool gain_assist)
+uint8_t setFlags(bool gain_assist, bool network_trigger)
 {
     // Range in metres
     uint8_t flags = 0x01;
@@ -101,6 +101,10 @@ uint8_t setFlags(bool gain_assist)
 
     // Enable 512 beams
     flags |= 0x40;
+
+    if (network_trigger) {
+        flags |= 0x80;
+    }
 
     return flags;
 }

--- a/src/Driver.cpp
+++ b/src/Driver.cpp
@@ -53,9 +53,9 @@ std::optional<base::samples::Sonar> Driver::processOne()
     return std::nullopt;
 }
 
-static uint8_t setFlags(bool gain_assist, bool network_trigger);
+static uint8_t setFlags(bool gain_assist);
 
-void Driver::fireSonar(M750DConfiguration const& config, bool network_trigger)
+void Driver::fireSonar(M750DConfiguration const& config, UpdateRate update_rate)
 {
     OculusSimpleFireMessage2 simple_fire_message;
     memset(&simple_fire_message, 0, sizeof(OculusSimpleFireMessage));
@@ -63,10 +63,10 @@ void Driver::fireSonar(M750DConfiguration const& config, bool network_trigger)
     simple_fire_message.head.srcDeviceId = 0;
     simple_fire_message.head.dstDeviceId = 0;
     simple_fire_message.head.oculusId = 0x4f53;
-    uint8_t flags = setFlags(config.gain_assist, network_trigger);
+    uint8_t flags = setFlags(config.gain_assist);
+    simple_fire_message.pingRate = static_cast<PingRateType>(update_rate);
     simple_fire_message.flags = flags;
     simple_fire_message.gammaCorrection = config.gamma;
-    simple_fire_message.pingRate = pingRateHigh;
     simple_fire_message.networkSpeed = config.net_speed_limit;
     simple_fire_message.masterMode = config.mode;
     simple_fire_message.range = config.range;
@@ -86,7 +86,7 @@ void Driver::fireSonar(M750DConfiguration const& config, bool network_trigger)
         sizeof(OculusSimpleFireMessage));
 }
 
-uint8_t setFlags(bool gain_assist, bool network_trigger)
+uint8_t setFlags(bool gain_assist)
 {
     // Range in metres
     uint8_t flags = 0x01;
@@ -101,10 +101,6 @@ uint8_t setFlags(bool gain_assist, bool network_trigger)
 
     // Enable 512 beams
     flags |= 0x40;
-
-    if (network_trigger) {
-        flags |= 0x80;
-    }
 
     return flags;
 }

--- a/src/Driver.hpp
+++ b/src/Driver.hpp
@@ -25,13 +25,10 @@ namespace sonar_oculus_m750d {
          */
 
         /**
-         * @brief  It calls a sonar reconfiguration
+         * @brief It calls a sonar reconfiguration
          *
          * @param configuration The sonar paramenters
-         * @param network_trigger Indicates whether the sonar requires an external trigger
-         * to send messages.
-         * true -> Oculus only fires when intructed.
-         * false -> Oculus fires automatically according to PingRate.
+         * @param update_rate The sonar update rate
          */
         void fireSonar(M750DConfiguration const& configuration, UpdateRate update_rate);
         Protocol m_protocol;

--- a/src/Driver.hpp
+++ b/src/Driver.hpp
@@ -7,6 +7,7 @@
 #include <optional>
 #include <sonar_oculus_m750d/M750DConfiguration.hpp>
 #include <sonar_oculus_m750d/Protocol.hpp>
+#include <sonar_oculus_m750d/UpdateRate.hpp>
 
 namespace sonar_oculus_m750d {
     class Driver : public iodrivers_base::Driver {
@@ -32,7 +33,7 @@ namespace sonar_oculus_m750d {
          * true -> Oculus only fires when intructed.
          * false -> Oculus fires automatically according to PingRate.
          */
-        void fireSonar(M750DConfiguration const& configuration, bool network_trigger);
+        void fireSonar(M750DConfiguration const& configuration, UpdateRate update_rate);
         Protocol m_protocol;
 
     private:

--- a/src/Driver.hpp
+++ b/src/Driver.hpp
@@ -22,7 +22,17 @@ namespace sonar_oculus_m750d {
          * This is also needed to keep the sonar alive
          *
          */
-        void fireSonar(M750DConfiguration const& configuration);
+
+        /**
+         * @brief  It calls a sonar reconfiguration
+         *
+         * @param configuration The sonar paramenters
+         * @param network_trigger Indicates whether the sonar requires an external trigger
+         * to send messages.
+         * true -> Oculus only fires when intructed.
+         * false -> Oculus fires automatically according to PingRate.
+         */
+        void fireSonar(M750DConfiguration const& configuration, bool network_trigger);
         Protocol m_protocol;
 
     private:

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -35,11 +35,10 @@ int main(int argc, char const* argv[])
     conf.range = 120;
     conf.salinity = 35;
     conf.speed_of_sound = 1500;
-    driver.fireSonar(conf, true);
+    driver.fireSonar(conf, UPDATE_10HZ_MAX);
     while (true) {
         auto sonar = driver.processOne();
         if (sonar) {
-            driver.fireSonar(conf, false);
             std::cout << "bins size = " << sonar->bins.size() << std::endl;
         }
     }

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -35,11 +35,11 @@ int main(int argc, char const* argv[])
     conf.range = 120;
     conf.salinity = 35;
     conf.speed_of_sound = 1500;
-    driver.fireSonar(conf);
+    driver.fireSonar(conf, true);
     while (true) {
         auto sonar = driver.processOne();
         if (sonar) {
-            driver.fireSonar(conf);
+            driver.fireSonar(conf, false);
             std::cout << "bins size = " << sonar->bins.size() << std::endl;
         }
     }

--- a/src/UpdateRate.hpp
+++ b/src/UpdateRate.hpp
@@ -1,0 +1,17 @@
+#ifndef SONAR_OCULUS_M750D_UPDATERATE_HPP
+#define SONAR_OCULUS_M750D_UPDATERATE_HPP
+
+#include <stdint.h>
+
+namespace sonar_oculus_m750d {
+    enum UpdateRate : uint8_t {
+        UPDATE_10HZ_MAX = 0x00, // 10Hz max ping rate
+        UPDATE_15HZ_MAX = 0x01, // 15Hz max ping rate
+        UPDATE_40HZ_MAX = 0x02, // 40Hz max ping rate
+        UPDATE_5HZ_MAX = 0x03,  // 5Hz max ping rate
+        UPDATE_2HZ_MAX = 0x04,  // 2Hz max ping rate
+        UPDATE_STANDBY = 0x05   // Disable ping
+    };
+}
+
+#endif


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/tidewise/drivers-orogen-sonar_oculus_m750d/pull/6

# What is this PR for
feat: make the network trigger flag set configurable

# Checklist
- [x] Assign yourself  in the PR
